### PR TITLE
adds the ability to return both base64 strings and an HTML5 FileList

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ npm install react-file-reader --save
 ```
 
 ## ChangeLog
+  - 1.0.4
+    - adds the ability to return both base64 strings and an HTML5 FileList from handleFiles
   - 1.0.3
     - bumps React version to 15.5 and fixes UNMET peer dependency with webpack
   - 1.0.2
@@ -84,6 +86,19 @@ handleFiles = files => {
 ```
   "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAA..."
 ```
+
+### Both Base64 and HTML5 FileList
+```javascript
+handleFiles = (base64Files, fileList) => {
+  console.log(base64Files);
+  console.log(fileList);
+}
+
+<ReactFileReader base64={true} multipleFiles={true} handleFiles={this.handleFiles}>
+  <button className='btn'>Upload</button>
+</ReactFileReader>
+```
+When `base64={true}`, `handleFiles` will return both the Base64 string and the HTML5 FileList object.
 
 ## Copyright
 Copyright (c)2017 [Grillwork Inc](http://grillwork.io). See [LICENSE](https://github.com/GrillWork/react-file-reader/blob/master/LICENSE) for details.

--- a/ReactFileReader.js
+++ b/ReactFileReader.js
@@ -35,7 +35,7 @@ export default class ReactFileReader extends React.Component {
           files.push(reader.result)
 
           if (files.length === ef.length) {
-            this.props.handleFiles(files);
+            this.props.handleFiles(files, ef);
           }
         }
 
@@ -46,7 +46,7 @@ export default class ReactFileReader extends React.Component {
       let reader = new FileReader();
 
       reader.onloadend = function (e) {
-        this.props.handleFiles(reader.result)
+        this.props.handleFiles(reader.result, ef)
       }.bind(this)
 
       reader.readAsDataURL(f)

--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ var ReactFileReader = function (_React$Component) {
               files.push(reader.result);
 
               if (files.length === ef.length) {
-                _this.props.handleFiles(files);
+                _this.props.handleFiles(files, ef);
               }
             };
 
@@ -85,7 +85,7 @@ var ReactFileReader = function (_React$Component) {
         var _reader = new FileReader();
 
         _reader.onloadend = function (e) {
-          this.props.handleFiles(_reader.result);
+          this.props.handleFiles(_reader.result, ef);
         }.bind(_this);
 
         _reader.readAsDataURL(f);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-file-reader",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "A flexible ReactJS component for handling styled HTML file inputs.",
   "main": "index.js",
   "repository": "git@github.com:GrillWork/react-file-reader.git",


### PR DESCRIPTION
enhancement: https://github.com/GrillWork/react-file-reader/issues/1

`handleFiles` now returns both the base64 string and the HTML5 FileList when `base64={true}`. The FileList object can be accessed as the second argument of the callback function provided to the `handleFiles` attribute.