### PR TITLE
Add support for user-land classname prop

### DIFF
--- a/ReactFileReader.js
+++ b/ReactFileReader.js
@@ -63,8 +63,13 @@ export default class ReactFileReader extends React.Component {
       position: 'fixed',
     }
 
+    var classNames = ['react-file-reader'];
+    if(this.props.className){
+      classNames.push(this.props.className);
+    }
+
     return(
-      <div className='react-file-reader'>
+      <div className={classNames.join(' ')}>
         <input type='file'
           onChange={this.handleFiles}
           accept={Array.isArray(this.props.fileTypes) ? this.props.fileTypes.join(',') : this.props.fileTypes}


### PR DESCRIPTION
At the moment it is not possible to provide a className for the component to apply, as the outer div uses a hard-coded className value.
I have updated this so that, with no user-provided className prop it behaves as before, but with a className prop both outer styles will be applied